### PR TITLE
Fix handling offset value when find criteria is nothing

### DIFF
--- a/FMDataAPI.php
+++ b/FMDataAPI.php
@@ -295,7 +295,7 @@ class FileMakerLayout
                 $request["query"] = $condition;
                 $this->restAPI->callRestAPI("find", $this->layout, true, "POST", $request);
             } else {
-                $this->restAPI->callRestAPI("record", $this->layout, true);
+                $this->restAPI->callRestAPI("record", $this->layout, true, "GET", $request);
             }
             $this->restAPI->storeToProperties();
             $result = $this->restAPI->responseBody;


### PR DESCRIPTION
Fixed handling offset value when find criteria (value of $condition) is nothing.