### PR TITLE
Fix handling range value when find criteria is nothing

### DIFF
--- a/FMDataAPI.php
+++ b/FMDataAPI.php
@@ -982,6 +982,9 @@ class CommunicationProvider
         if ($methodLower == 'get' && !is_null($request)) {
             $url .= '?';
             foreach ($request as $key => $value) {
+                if (key($request) !== $key) {
+                    $url .= '&';
+                }
                 $url .= $key . '=' . (is_array($value) ? json_encode($value) : $value);
             }
         }


### PR DESCRIPTION
Fixed handling range value when find criteria (value of $condition) is nothing.
Related Issue: #2