### PR TITLE
Fix creating an empty record

### DIFF
--- a/FMDataAPI.php
+++ b/FMDataAPI.php
@@ -1081,7 +1081,13 @@ class CommunicationProvider
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
         if ($methodLower != 'get') {
-            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($request));
+            if ($methodLower === 'post' && isset($request['data']) &&
+                $request['data'] === array() && $recordId === NULL) {
+                // create an empty record
+                curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($request, JSON_FORCE_OBJECT));
+            } else {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($request));
+            }
         }
         $response = curl_exec($ch);
         $this->curlInfo = curl_getinfo($ch);


### PR DESCRIPTION
According to FileMaker 16 Data API Guide <https://fmhelp.filemaker.com/docs/16/en/restapi/>, it's need to specify an empty data object in JSON format as the parameter to create an empty record.

{"data": {}}