### PR TITLE
Cast a number of parameters in query() to string to avoid an error

### DIFF
--- a/FMDataAPI.php
+++ b/FMDataAPI.php
@@ -1102,7 +1102,9 @@ class CommunicationProvider
             if (isset($request['query'])) {
                 foreach ($request['query'] as $key => $array) {
                     foreach ($array as $fieldName => $fieldValue) {
-                        $request['query'][$key][$fieldName] = (string)$fieldValue;
+                        if (!is_array($fieldValue)) {
+                            $request['query'][$key][$fieldName] = (string)$fieldValue;
+                        }
                     }
                 }
             }

--- a/FMDataAPI.php
+++ b/FMDataAPI.php
@@ -1091,6 +1091,22 @@ class CommunicationProvider
                 }
             }
         } else if ($methodLower !== 'get' && !is_null($request)) {
+            // cast a number
+            if (isset($request['data'])) {
+                foreach ($request['data'] as $fieldName => $fieldValue) {
+                    if (is_numeric($fieldValue)) {
+                        $request['data'][$fieldName] = (string)$fieldValue;
+                    }
+                }
+            }
+            if (isset($request['query'])) {
+                foreach ($request['query'] as $key => $array) {
+                    foreach ($array as $fieldName => $fieldValue) {
+                        $request['query'][$key][$fieldName] = (string)$fieldValue;
+                    }
+                }
+            }
+
             if (isset($request['sort'])) {
                 $sort = array();
                 foreach ($request['sort'] as $sortKey => $sortCondition) {


### PR DESCRIPTION
This pull request allows a NUMBER of parameters in query(). Please consider the following usage to avoid an error (HTTP Status Code: 477. FileMaker Data API / Error Code: 507, Error Message: Value in field failed calculation test of validation entry option.).

Example Usage:
$fmdb->person_layout->query(array(array("id" => 1)))

Related pull request: #10