### PR TITLE
Fix running FileMaker scripts when deleting a record

### DIFF
--- a/FMDataAPI.php
+++ b/FMDataAPI.php
@@ -490,12 +490,12 @@ class FileMakerLayout
         try {
             $this->restAPI->login();
             $request = [];
-            $headers = [];
-            $params = ["layouts" => $this->layout, "records" => $recordId];
+            $headers = NULL;
+            $params = ['layouts' => $this->layout, 'records' => $recordId];
             if (!is_null($script)) {
-                $request = array_merge($request, $this->buildScriptParameters($script));
+                $request = $this->buildScriptParameters($script);
             }
-            $this->restAPI->callRestAPI($params, true, "DELETE", null, $headers);
+            $this->restAPI->callRestAPI($params, true, 'DELETE', $request, $headers);
             $this->restAPI->storeToProperties();
             $this->restAPI->logout();
         } catch (\Exception $e) {
@@ -1258,7 +1258,7 @@ class CommunicationProvider
         $jsonEncoding = true;
         if (is_string($request)) {
             $jsonEncoding = false;
-        } else if ($methodLower === 'get' && !is_null($request)) {
+        } else if (in_array($methodLower, array('get', 'delete')) && !is_null($request)) {
             $url .= '?';
             foreach ($request as $key => $value) {
                 if (key($request) !== $key) {


### PR DESCRIPTION
According to FileMaker 17 Data API Guide,  "You can run FileMaker scripts as part of this request by including the script.prerequest, script.presort, and script parameters in the URL.".

https://fmhelp.filemaker.com/docs/17/en/dataapi/