### PR TITLE
Typo "in" PHP, not "by" PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 by Masayuki Nii (nii@msyk.net)
 
-FMDataAPI is a class developed by PHP to access FileMaker database
+FMDataAPI is a class developed in PHP to access FileMaker database
 with FileMaker Data API.
 
 ## Contributers


### PR DESCRIPTION
I suggest this change, since while comparing different Filemaker Data API wrappers this induced me in error. 
Thinking that this library was backed by the PHP core team.