### PR TITLE
Fix deprecation notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "prefer-stable": true,
   "require": {
-    "php": ">=5.5",
+    "php": ">=7.1",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/src/Supporting/FileMakerRelation.php
+++ b/src/Supporting/FileMakerRelation.php
@@ -159,7 +159,7 @@ class FileMakerRelation implements Iterator
     /**
      * The record pointer goes forward to previous record. This does not care the range of pointer value.
      */
-    public function next()
+    public function next(): void
     {
         $this->pointer++;
     }
@@ -522,7 +522,7 @@ class FileMakerRelation implements Iterator
      *
      * @return FileMakerRelation|null The record set of the current pointing record.
      */
-    public function current()
+    public function current(): ?FileMakerRelation
     {
         $value = null;
         if (isset($this->data) &&
@@ -548,7 +548,7 @@ class FileMakerRelation implements Iterator
      *
      * @return integer The current number as the record pointer.
      */
-    public function key()
+    public function key(): int
     {
         return $this->pointer;
     }
@@ -558,7 +558,7 @@ class FileMakerRelation implements Iterator
      *
      * @return bool Returns true on existing the record or false on not existing.
      */
-    public function valid()
+    public function valid(): bool
     {
         if (isset($this->data) &&
             isset($this->data[$this->pointer])
@@ -572,7 +572,7 @@ class FileMakerRelation implements Iterator
     /**
      * Rewind the Iterator to the first element. This method is implemented for Iterator interface.
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->pointer = 0;
     }

--- a/test/TestProvider.php
+++ b/test/TestProvider.php
@@ -44,7 +44,7 @@ class TestProvider extends CommunicationProvider
         $this->url = $url;
         $this->requestHeader = $header;
         $this->requestBody = ($methodLower != 'get') ? $request : null;
-        $this->responseBody = json_decode($response['response'], false, 512, JSON_BIGINT_AS_STRING);
+        $this->responseBody = json_decode($response['response'] ?? "", false, 512, JSON_BIGINT_AS_STRING);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bunch of Deprecation notices on php >= 8.0, this does sadly raise the minimum PHP version to 7.1 because return type hints aren't supported in earlier versions. 
I however don't think this should be a problem since version 7.1 has been deprecated for a while.