### PR TITLE
Fixed the missing error message texts

### DIFF
--- a/src/FMDataAPI.php
+++ b/src/FMDataAPI.php
@@ -194,6 +194,14 @@ class FMDataAPI
     {
         return $this->provider->curlErrorNumber;
     }
+    /**
+     * The error message of curl, text representation of code.
+     * @return int The error number of curl.
+     */
+    public function curlErrorMessage()
+    {
+        return $this->provider->curlError;
+    }
 
     /**
      * The HTTP status code of the latest response from the REST API.

--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -83,7 +83,7 @@ class CommunicationProvider
      * @var
      * @ignore
      */
-    protected $curlError;
+    public $curlError;
     /**
      * @var
      * @ignore
@@ -747,7 +747,7 @@ class CommunicationProvider
         $this->totalCount = null;
         $this->foundCount = null;
         $this->returnedCount = null;
-
+        $this->errorMessage = null;
 
         if (property_exists($this, 'responseBody')) {
             $rbody = $this->responseBody;
@@ -756,6 +756,7 @@ class CommunicationProvider
                     $result = $rbody->messages[0];
                     $this->httpStatus = $this->getCurlInfo("http_code");
                     $this->errorCode = property_exists($result, 'code') ? $result->code : -1;
+                    $this->errorMessage = property_exists($result, 'message') && $result->code != 0 ? $result->message : null;
                 }
                 if (property_exists($rbody, 'response')) {
                     $result = $rbody->response;


### PR DESCRIPTION
Fixed the missing error message texts when database connection doesn't work.
Added text messages for curl errors and population of text messages when login does not work.
I missed them from time to time when troubleshooting deployments or installing.