### PR TITLE
Correct the type of CommunicationProvider's $responseBody property

### DIFF
--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -120,7 +120,7 @@ class CommunicationProvider
      */
     public $returnedCount = 0;
     /**
-     * @var string
+     * @var object
      * @ignore
      */
     public $responseBody;


### PR DESCRIPTION
To avoid warnings in the code, the `$responseBody` property should be an *object* and not a *string*. This is because it is set in `->callRestAPI()` with a `json_decode()`, which returns an object.