### PR TITLE
Resolve "PHPDoc tag @throws with type INTERMediator\FileMakerServer\RESTAPI\Supporting\Exception is not subtype of Throwable" detected by PHPStan

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,12 +17,12 @@ jobs:
         include:
           - current-level: 0
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@72ae4ccbe57f82bbe08411e84e2130bd4ba1c10f # v2.25.5
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
         with:
-          php-version: '8.1'
+          php-version: '8.3'
 
       - name: Install PHPStan
         run: composer require --dev phpstan/phpstan

--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -361,7 +361,7 @@ class CommunicationProvider
     }
 
     /**
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function getProductInfo()
@@ -386,7 +386,7 @@ class CommunicationProvider
     }
 
     /**
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function getDatabaseNames()
@@ -419,7 +419,7 @@ class CommunicationProvider
     }
 
     /**
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function getLayoutNames()
@@ -445,7 +445,7 @@ class CommunicationProvider
     }
 
     /**
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function getScriptNames()
@@ -471,7 +471,7 @@ class CommunicationProvider
     }
 
     /**
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function login()
@@ -512,7 +512,7 @@ class CommunicationProvider
 
     /**
      *
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function logout()
@@ -574,7 +574,7 @@ class CommunicationProvider
      * @param array $request
      * @param array $addHeader
      * @param boolean $isSystem for Metadata
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      * @ignore
      */
     public function callRestAPI($params, $isAddToken, $method = 'GET', $request = null, $addHeader = null, $isSystem = false, $directPath = false)

--- a/src/Supporting/FileMakerLayout.php
+++ b/src/Supporting/FileMakerLayout.php
@@ -475,7 +475,7 @@ class FileMakerLayout
      * information is set under the 'metaData' property. There is no information about portals. Ex.:
      * {"metaData": [{"name": "id","type": "normal","result": "number","global": "false","repetitions": 1,"id": "1"},
      *{"name": "name","type": "normal","result": "text","global": "false","repetitions": 1,"id": "2"},,....,]}
-     * @throws Exception In case of any error, an exception arises.
+     * @throws \Exception In case of any error, an exception arises.
      */
     public function getMetadataOld()
     {

--- a/src/Supporting/FileMakerRelation.php
+++ b/src/Supporting/FileMakerRelation.php
@@ -374,7 +374,7 @@ class FileMakerRelation implements Iterator
      * @param string $toName The table occurrence name of the portal as the prefix of the field name.
      *
      * @return string|FileMakerRelation The field value as string, or the FileMakerRelation object of the portal.
-     * @throws Exception The field specified in parameters doesn't exist.
+     * @throws \Exception The field specified in parameters doesn't exist.
      * @see FMDataAPI::setFieldHTMLEncoding() Compatible mode for FileMaker API for PHP.
      *
      */


### PR DESCRIPTION
I have replaced “throws Exception” with “throws \Exception”. 8 errors reduced.