### PR TITLE
Modify workflow files for multiple platforms testing

### DIFF
--- a/.github/workflows/php-7.2.dockerfile
+++ b/.github/workflows/php-7.2.dockerfile
@@ -1,0 +1,25 @@
+FROM php:7.2-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install mbstring bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-7.3.dockerfile
+++ b/.github/workflows/php-7.3.dockerfile
@@ -1,0 +1,25 @@
+FROM php:7.3-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install mbstring bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-7.4.dockerfile
+++ b/.github/workflows/php-7.4.dockerfile
@@ -1,0 +1,25 @@
+FROM php:7.4-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-8.0.dockerfile
+++ b/.github/workflows/php-8.0.dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=linux/amd64 php:8.0-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd ldap
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-8.1.dockerfile
+++ b/.github/workflows/php-8.1.dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=linux/amd64 php:8.1-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd ldap
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-8.2.dockerfile
+++ b/.github/workflows/php-8.2.dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=linux/amd64 php:8.2-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd ldap
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-8.3.dockerfile
+++ b/.github/workflows/php-8.3.dockerfile
@@ -1,0 +1,25 @@
+FROM --platform=linux/amd64 php:8.3-apache
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    iputils-ping \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    mariadb-client \
+    postgresql-client \
+    sqlite3 \
+    sudo \
+    unzip \
+    vim \
+ && apt-get -y clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install bcmath zip pdo pdo_mysql pdo_pgsql pdo_sqlite exif gd ldap
+COPY composer.json /composer.json
+COPY composer.lock /composer.lock
+COPY src /src
+COPY test /test
+RUN curl -sS https://getcomposer.org/installer | php; mv composer.phar /usr/local/bin/composer; chmod +x /usr/local/bin/composer
+RUN cd / && composer update
+#RUN composer test

--- a/.github/workflows/php-multiplatform.yml
+++ b/.github/workflows/php-multiplatform.yml
@@ -1,0 +1,39 @@
+name: Test on multiple platforms
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches: [ 'master', 'main' ]
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 9 15 * *'
+
+jobs:
+  test:
+    name: Test on multiple platforms
+    runs-on: ${{ matrix.os }}
+    env:
+      PHP_EXTENSIONS: mbstring, json, bcmath, zip, pdo, pdo_mysql, pdo_pgsql, pdo_sqlite, exif, gd, ldap, fileinfo
+    strategy:
+      matrix:
+        # https://github.com/shivammathur/setup-php?tab=readme-ov-file#cloud-osplatform-support
+        os: [ 'ubuntu-24.04', 'windows-2022', 'macos-13' ]
+        php: [ '8.3' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PHP with extensions
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: pcov
+          extensions: ${{ env.PHP_EXTENSIONS }}
+
+      - name: Prepare environment
+        run: composer install
+
+      - name: Run testing
+        run: composer test

--- a/.github/workflows/php-src.yml
+++ b/.github/workflows/php-src.yml
@@ -2,7 +2,6 @@ name: Test with php-src
 
 on:
   pull_request:
-    branches: [ 'master', 'main' ]
   workflow_dispatch:
   schedule:
     - cron:  '0 9 7,14,21,28 * *'
@@ -15,7 +14,7 @@ jobs:
       matrix:
         php: [ '8.1', '8.2', '8.3', '8.4' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Run docker compose
         shell: bash
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,4 +27,4 @@ jobs:
         shell: bash
         run: |
           sleep 30
-          docker-compose exec -T web sh -c "cd / && composer test"
+          docker-compose exec -T web sh -c "cd / && php -v && composer test"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,7 +2,10 @@ name: Test
 
 on:
   push:
+    branches:
+      - "*"
   pull_request:
+    branches: [ 'master', 'main' ]
   workflow_dispatch:
   schedule:
     - cron:  '0 9 15 * *'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,10 +2,7 @@ name: Test
 
 on:
   push:
-    branches:
-      - "*"
   pull_request:
-    branches: [ 'master', 'main' ]
   workflow_dispatch:
   schedule:
     - cron:  '0 9 15 * *'
@@ -13,28 +10,21 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
-    env:
-      PHP_EXTENSIONS: mbstring, json, bcmath, zip, pdo, pdo_mysql, pdo_pgsql, pdo_sqlite, exif, gd, ldap, fileinfo
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install PHP with extensions
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
-        with:
-          php-version: ${{ matrix.php-version }}
-          coverage: pcov
-          extensions: ${{ env.PHP_EXTENSIONS }}
-
-      - name: Prepare environment
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Run docker-compose
         shell: bash
-        run: composer install
+        run: |
+          cp .github/workflows/php-${{ matrix.php }}.dockerfile Dockerfile
+          docker-compose up -d
+          sleep 30
 
       - name: Run testing
         shell: bash
-        run: composer test
+        run: |
+          sleep 30
+          docker-compose exec -T web sh -c "cd / && composer test"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,4 +1,4 @@
-name: run-phpstan
+name: PHPStan
 
 on:
   push:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,4 +1,4 @@
-name: PHPStan
+name: run-phpstan
 
 on:
   push:


### PR DESCRIPTION
Sorry, this PR reverts dockerfiles to address the issue of not being able to test with older versions of PHP in #82 .
This PR adds .github/workflows/php-multiplatform.yml for testing on Ubuntu Linux, Windows and macOS with PHP 8.3 only.