### PR TITLE
Trying to fix types in PHP Documentor comments, to help auto-complete and linters do their job

### DIFF
--- a/src/FMDataAPI.php
+++ b/src/FMDataAPI.php
@@ -4,6 +4,7 @@ namespace INTERMediator\FileMakerServer\RESTAPI;
 
 use INTERMediator\FileMakerServer\RESTAPI\Supporting\FileMakerLayout;
 use INTERMediator\FileMakerServer\RESTAPI\Supporting\FileMakerRelation;
+use INTERMediator\FileMakerServer\RESTAPI\Supporting\CommunicationProvider;
 use Exception;
 
 /**
@@ -26,12 +27,13 @@ class FMDataAPI
      */
 
     /**
-     * Keeping the FileMakerLayout object for each layout
+     * @var FileMakerLayout[] Keeping the FileMakerLayout object for each layout.
      * @ignore
      */
     private $layoutTable = [];
+    
     /**
-     * Keeping the CommunicationProvider object
+     * @var null|CommunicationProvider Keeping the CommunicationProvider object.
      * @ignore
      */
     private $provider = null;
@@ -40,7 +42,7 @@ class FMDataAPI
      * FMDataAPI constructor. If you want to activate OAuth authentication, $user and $password are set as
      * oAuthRequestId and oAuthIdentifier. Moreover, call useOAuth method before accessing layouts.
      * @param string $solution The database file name which is just hosting.
-     * Every database must have the access privillege 'fmrest' including external data sources.
+     * Every database must have the access privilege 'fmrest' including external data sources.
      * @param string $user The fmrest privilege accessible user to the database.
      * If you are going to call useOAuth method, you have to specify the data for X-FM-Data-OAuth-Request-Id.
      * @param string $password The password of above user.
@@ -51,7 +53,7 @@ class FMDataAPI
      * @param string $protocol FileMaker Server's protocol name. If omitted, 'https' is chosen.
      * @param array $fmDataSource Authentication information for external data sources.
      * Ex.  [{"database"=>"<databaseName>", "username"=>"<username>", "password"=>"<password>"].
-     * If you use OAuth, "oAuthRequestId" and "oAuthIdentifier" keys have to be spedified.
+     * If you use OAuth, "oAuthRequestId" and "oAuthIdentifier" keys have to be specified.
      * @param boolean $isUnitTest If it's set to true, the communication provider just works locally.
      */
     public function __construct(
@@ -163,7 +165,7 @@ class FMDataAPI
      * Detect the return value of the field() method uses htmlspecialchars function or not.
      * @return bool The result.
      */
-    public function getFieldHTMLEncoding($value)
+    public function getFieldHTMLEncoding()
     {
         return $this->provider->fieldHTMLEncoding;
     }
@@ -226,7 +228,7 @@ class FMDataAPI
     /**
      * The error message of the latest response from the REST API.
      * This error message is associated with FileMaker's error code.
-     * @return string The error messege.
+     * @return string The error message.
      */
     public function errorMessage()
     {

--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -34,7 +34,7 @@ class CommunicationProvider
      */
     private $password = "1234";
     /**
-     * @var
+     * @var string
      * @ignore
      */
     private $solution;
@@ -115,7 +115,7 @@ class CommunicationProvider
      */
     public $foundCount = 0;
     /**
-     * @varint
+     * @var int
      * @ignore
      */
     public $returnedCount = 0;
@@ -213,12 +213,12 @@ class CommunicationProvider
 
     /**
      * CommunicationProvider constructor.
-     * @param $solution
-     * @param $user
-     * @param $password
-     * @param null $host
-     * @param null $port
-     * @param null $protocol
+     * @param string $solution
+     * @param string $user
+     * @param string $password
+     * @param null|string $host
+     * @param null|int $port
+     * @param null|string $protocol
      * @ignore
      */
     public function __construct($solution, $user, $password, $host = null, $port = null, $protocol = null, $fmDataSource = null)
@@ -247,9 +247,11 @@ class CommunicationProvider
     }
 
     /**
-     * @param $action
-     * @param $layout
-     * @param null $recordId
+     * @param array $params Array to build the API path. Ex: `["layouts" => null]` or `["sessions" => $this->accessToken]`.
+     * @param null|array $request The query parameters as `"key" => "value"`.
+     * @param string $methodLower The method in lowercase. Ex: `"get"`, `"delete"`, etc.
+     * @param bool $isSystem If the query is for the system (sessions, databases, etc) or for a database.
+     * @param false|string $directPath If we don't want to build the path with the other parameters, you can provide the direct path.
      * @return string
      * @ignore
      */

--- a/src/Supporting/FileMakerLayout.php
+++ b/src/Supporting/FileMakerLayout.php
@@ -22,15 +22,15 @@ class FileMakerLayout
      */
     private $restAPI = null;
     /**
-     * @var null
+     * @var null|string
      * @ignore
      */
     private $layout = null;
 
     /**
      * FileMakerLayout constructor.
-     * @param $restAPI
-     * @param $layout
+     * @param CommunicationProvider $restAPI
+     * @param string $layout
      * @ignore
      */
     public function __construct($restAPI, $layout)
@@ -86,7 +86,7 @@ class FileMakerLayout
     }
 
     /**
-     * @param $param
+     * @param array $param
      * @return array
      * @ignore
      */

--- a/src/Supporting/FileMakerRelation.php
+++ b/src/Supporting/FileMakerRelation.php
@@ -21,7 +21,7 @@ Ver * @version 31
 class FileMakerRelation implements Iterator
 {
     /**
-     * @var null|array
+     * @var null|object
      * @ignore
      */
     private $data = null;
@@ -194,13 +194,12 @@ class FileMakerRelation implements Iterator
             case "OK":
             case "PORTAL":
                 return count($this->data);
-                break;
             case "RECORD":
             case "PORTALRECORD":
                 return 1;
-                break;
+            default:
+                return 0;
         }
-        return 0;
     }
 
     /**


### PR DESCRIPTION
They are certainly a lot of other places where one could improve the _PHP Documentor_ comments, and I see how much time it takes to add/improve them. My _VS Code_ and _Sonar_ helps me a bit in finding things to improve.

Hope this can help a bit!

Thanks for this great lib to access _FileMaker_ :-)