### PR TITLE
Create the cURL handle at a single place to avoid code redundancy

### DIFF
--- a/src/Supporting/FileMakerLayout.php
+++ b/src/Supporting/FileMakerLayout.php
@@ -90,17 +90,19 @@ class FileMakerLayout
      * @return array
      * @ignore
      */
-    private function buildScriptParameters($param)
+    private function buildScriptParameters(array $param)
     {
         $request = [];
-        $scriptKeys = ["script", "script.param", "script.prerequest", "script.prerequest.param",
-            "script.presort", "script.presort.param", "layout.response"];
+        $scriptKeys = [
+            "script", "script.param", "script.prerequest", "script.prerequest.param",
+            "script.presort", "script.presort.param", "layout.response"
+        ];
         foreach ($scriptKeys as $key) {
             if (isset($param[$key])) {
                 $request[$key] = $param[$key];
             }
         }
-        if (count($request) === 0) {
+        if (!empty($request)) {
             switch (count($request)) {
                 case 1:
                     $request["script"] = $param[0];
@@ -127,7 +129,7 @@ class FileMakerLayout
 
     /**
      * Query to the FileMaker Database and returns the result as FileMakerRelation object.
-     * @param array $condition The array of associated array which has a field name and "omit" keys as like:
+     * @param array|null $condition The array of associated array which has a field name and "omit" keys as like:
      * array(array("FamilyName"=>"Nii*", "Country"=>"Japan")).
      * In this example of apply the AND operation for two fields,
      * and "FamilyName" and "Country" are field name. The value can contain the operator:
@@ -137,19 +139,19 @@ class FileMakerLayout
      * If you want to omit records match with condition set the "omit" element as like:
      * array("FamilyName"=>"Nii*", "omit"=>"true").
      * If you want to query all records in the layout, set the first parameter to null.
-     * @param array $sort The array of array which has 2 elements as a field name and order key:
+     * @param array|null $sort The array of array which has 2 elements as a field name and order key:
      * array(array("FamilyName", "ascend"), array("GivenName", "descend")).
      * The value of order key can be 'ascend', 'descend' or value list name. The default value is 'ascend'.
      * @param int $offset The start number of the record set, and the first record is 1, but the number 0
      * queries from the first record. The default value is 0.
      * @param int $range The number of records contains in the result record set. The default value is 100.
-     * @param array $portal The array of the portal's object names. The query result is going to contain portals
+     * @param array|null $portal The array of the portal's object names. The query result is going to contain portals
      * specified in this parameter. If you want to include all portals, set it null or omit it.
      * Simple case is array('portal1', portal2'), and just includes two portals named 'portal1' and 'portal2'
      * in the query result. If you set the range of records to a portal, you have to build associated array as like:
      * array('portal1' => array('offset'=>1,'limit'=>5), 'portal2' => null). The record 1 to 5 of portal1 include
      * the query result, and also all records in portal2 do.
-     * @param array $script scripts that should execute right timings.
+     * @param array|null $script scripts that should execute right timings.
      * The most understandable description is an associated array with API's keywords "script", "script.param",
      * "script.prerequest", "script.prerequest.param", "script.presort", "script.presort.param", "layout.response."
      * These keywords have to be a key, and the value is script name or script parameter,
@@ -161,7 +163,8 @@ class FileMakerLayout
      * @return FileMakerRelation|null Query result.
      * @throws Exception In case of any error, an exception arises.
      */
-    public function query($condition = null, $sort = null, $offset = 0, $range = 0, $portal = null, $script = null)
+    public function query(array|null $condition = null, array|null $sort = null, int $offset = 0,
+                          int $range = 0, array|null $portal = null, array|null $script = null)
     {
         try {
             if ($this->restAPI->login()) {

--- a/src/Supporting/FileMakerRelation.php
+++ b/src/Supporting/FileMakerRelation.php
@@ -3,6 +3,7 @@
 namespace INTERMediator\FileMakerServer\RESTAPI\Supporting;
 
 use Iterator;
+use Exception;
 
 /**
  * Class FileMakerRelation is the record set of queried data. This class implements Iterator interface.
@@ -69,7 +70,7 @@ class FileMakerRelation implements Iterator
      * @ignore
      */
     public function __construct(array|object $responseData, object|array $infoData, string $result = "PORTAL",
-                                int   $errorCode = 0, ?string $portalName = null, CommunicationProvider $provider = null)
+                                int $errorCode = 0, ?string $portalName = null, CommunicationProvider $provider = null)
     {
         $this->data = $responseData;
         $this->dataInfo = $infoData;
@@ -387,7 +388,7 @@ class FileMakerRelation implements Iterator
                         if (isset($this->data[$this->pointer]->fieldData->$name)
                         ) {
                             $value = $this->data[$this->pointer]->fieldData->$name;
-                        } else if (isset($this->data[$this->pointer]->portalData->$name)
+                        } elseif (isset($this->data[$this->pointer]->portalData->$name)
                         ) {
                             $infoData = property_exists($this->data[$this->pointer], 'portalDataInfo') ?
                                 $this->data[$this->pointer]->portalDataInfo : null;
@@ -405,11 +406,11 @@ class FileMakerRelation implements Iterator
                 case "RECORD":
                     if (isset($this->data->fieldData->$name)) {
                         $value = $this->data->fieldData->$name;
-                    } else if (isset($this->data->portalData->$name)) {
+                    } elseif (isset($this->data->portalData->$name)) {
                         $infoData = property_exists($this->data, 'portalDataInfo') ? $this->data->portalDataInfo : null;
                         $value = new FileMakerRelation($this->data->portalData->$name, $infoData,
                             "PORTAL", 0, $name, $this->restAPI);
-                    } else if (isset($this->data->fieldData->$fieldName)) {
+                    } elseif (isset($this->data->fieldData->$fieldName)) {
                         $value = $this->data->fieldData->$fieldName;
                     }
                     break;
@@ -417,7 +418,7 @@ class FileMakerRelation implements Iterator
                     $convinedName = "{$this->portalName}::{$fieldName}";
                     if (isset($this->data->$fieldName)) {
                         $value = $this->data->$fieldName;
-                    } else if (isset($this->data->$convinedName)) {
+                    } elseif (isset($this->data->$convinedName)) {
                         $value = $this->data->$convinedName;
                     }
                     break;

--- a/test/TestProvider.php
+++ b/test/TestProvider.php
@@ -11,7 +11,24 @@ namespace INTERMediator\FileMakerServer\RESTAPI\Supporting;
 class TestProvider extends CommunicationProvider
 {
 
-    public function __construct($solution, $user, $password, $host = NULL, $port = NULL, $protocol = NULL, $fmDataSource = NULL)
+    /**
+     * TestProvider constructor.
+     * @param string $solution
+     * @param string $user
+     * @param string $password
+     * @param string|null $host
+     * @param string|null $port
+     * @param string|null $protocol
+     * @param array|null $fmDataSource
+     * @param string $solution
+     * @param string $user
+     * @param string $password
+     * @param null|string $host
+     * @param null|int $port
+     * @param null|string $protocol
+     * @ignore
+     */
+    public function __construct($solution, $user, $password, $host = null, $port = null, $protocol = null, $fmDataSource = null)
     {
         parent::__construct($solution, $user, $password, $host, $port, $protocol, $fmDataSource);
         $this->buildResponses();
@@ -19,13 +36,19 @@ class TestProvider extends CommunicationProvider
 
     /**
      * Override communication method.
-     * @param $params
-     * @param $isAddToken
+     * @param array $params
+     * @param bool $isAddToken
      * @param string $method
-     * @param null $request
-     * @param null $addHeader
+     * @param array|null $request
+     * @param array|null $addHeader
+     * @param bool $isSystem for Metadata
+     * @param string|null|false $directPath
+     * @return void
+     * @throws Exception In case of any error, an exception arises.
+     * @ignore
      */
-    public function callRestAPI($params, $isAddToken, $method = 'GET', $request = NULL, $addHeader = null, $isSystem = false, $directPath = false)
+    public function callRestAPI(array $params, bool $isAddToken, string $method = 'GET', $request = null,
+                                $addHeader = null, $isSystem = false, string|null|false $directPath = null)
     {
         $methodLower = strtolower($method);
         $url = $this->getURL($params, $request, $methodLower);
@@ -51,11 +74,12 @@ class TestProvider extends CommunicationProvider
 
     /**
      * Override communication method.
-     * @param $url
+     * @param string $url
+     * @return string The base64 encoded data in container field.
      */
-    public function accessToContainer($url)
+    public function accessToContainer(string $url): string
     {
-
+        return "TODO TestProvider::accessToContainer()";
     }
 
     private function validResponse($input)


### PR DESCRIPTION
I noticed later that `curl_init()` was called at several places, so my fix to do the SSL certificate check by using the system root certificates didn't work for all cases. To avoid code duplication, I added a private function to create the cURL handle at a single place.

In the same time, I tried removing some warnings from _SonarLint_, such as `else if` which should be replaced by `elseif`.

Also tried to improve all the type declarations for some methods. About this topic, I don't know what is best to do, but I think that optional parameters should use `null` instead of `false`. But maybe some users may have used `false` in their calls, so to avoid breaking updates, it might be interesting to accept `false` or `null` and test if the parameter is the expected type, such as an array or a string or whatever else.