### PR TITLE
Fixed parameter "_" preset for limit and offset parameters for portals

### DIFF
--- a/src/Supporting/FileMakerLayout.php
+++ b/src/Supporting/FileMakerLayout.php
@@ -75,7 +75,7 @@ class FileMakerLayout
                                            string      $method = "GET"): array
     {
         $key = $shortKey ? "portal" : "portalData";
-        $prefix = $method === "GET" ? "" : "_";
+        $prefix = $method === "GET" ? "_" : "";
         $request = [];
         if (array_values($param) === $param) {
             $request[$key] = $param;


### PR DESCRIPTION
limit and offset parameters are prefixed with "_" in GET requests but not in POST.
Current version does the opposite and limit/offset option parameters on portaldata thows
"Warning: Undefined array key "offset" in .../FileMakerLayout.php on line 88" with getRecord() and 
HTTP 400 with Code 960: "Unknown parameter(s)" with query()