### PR TITLE
Resolve the "INTERMediator\FileMakerServer\RESTAPI\Supporting\CommunicationProvider::getOAuthIdentifier() never returns string so it can be removed from the return type" error detected by PHPStan

### DIFF
--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -550,10 +550,10 @@ class CommunicationProvider
 
     /**
      * @param $provider
-     * @return string|array|null
+     * @return array|null
      * @ignore
      */
-    private function getOAuthIdentifier($provider): string|array|null
+    private function getOAuthIdentifier($provider): array|null
     {
         try {
             $this->callRestAPI(


### PR DESCRIPTION
Resolved the following errors detected by PHPStan:
```
  556    Method                                                                               
         INTERMediator\FileMakerServer\RESTAPI\Supporting\CommunicationProvider::getOAuthIde  
         ntifier() never returns string so it can be removed from the return type.            
         🪪  return.unusedType 
```