### PR TITLE
Add "@phpstan-ignore method.unused" for CommunicationProvider::getSupportingProviders() and CommunicationProvider::getOAuthIdentifier()

### DIFF
--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -532,6 +532,7 @@ class CommunicationProvider
     /**
      * @return array|null
      * @ignore
+     * @phpstan-ignore method.unused
      */
     private function getSupportingProviders(): null|array
     {
@@ -552,6 +553,7 @@ class CommunicationProvider
      * @param $provider
      * @return array|null
      * @ignore
+     * @phpstan-ignore method.unused
      */
     private function getOAuthIdentifier($provider): array|null
     {


### PR DESCRIPTION
Added "@phpstan-ignore method.unused" for CommunicationProvider::getSupportingProviders() and CommunicationProvider::getOAuthIdentifier() to resolve errors detected by PHPStan level 4.