### PR TITLE
Set the rule level of PHPStan to 4

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        level: [ 3, 4 ]
+        level: [ 4, 5 ]
         include:
-          - current-level: 3
+          - current-level: 4
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 


### PR DESCRIPTION
Current Status (PHPStan 2.1.38):
- PHPStan Level 4 : No errors
- PHPStan Level 5 : Found 9 errors
- PHPStan Level 6 : Found 79 errors
- PHPStan Level 7 : Found 140 errors
- PHPStan Level 8 : Found 240 errors
- PHPStan Level 9 : Found 247 errors
- PHPStan Level 10 : Found 470 errors