### PR TITLE
Add mago.toml and mago.yml for GitHub Actions

### DIFF
--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -1,0 +1,25 @@
+name: Mago
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run:
+    name: Run Mago
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PHP
+        uses: ./.github/actions/setup-php
+
+      - name: Install Mago
+        run: composer config --no-plugins allow-plugins.carthage-software/mago true; composer require --dev carthage-software/mago:1.9.1
+
+      - name: Run Mago
+        run: ./vendor/bin/mago --config .mago/mago.toml analyze

--- a/.mago/mago.toml
+++ b/.mago/mago.toml
@@ -35,3 +35,11 @@ strict-list-index-checks = false
 no-boolean-literal-comparison = false
 check-missing-type-hints = false
 register-super-globals = true
+ignore = [
+    # error
+    "falsable-return-statement", "invalid-iterator", "invalid-property-access", "invalid-return-statement", "less-specific-argument", "mixed-argument", "mixed-array-access", "mixed-array-assignment", "mixed-operand", "mixed-property-access", "mixed-property-type-coercion", "mixed-return-statement", "non-existent-class", "nullable-return-statement", "possible-method-access-on-null", "possibly-false-argument", "possibly-invalid-argument", "possibly-null-argument", "possibly-null-property-access",
+    # warning
+    "ambiguous-object-property-access", "generic-object-iteration", "impossible-condition", "impossible-null-type-comparison", "impossible-type-comparison", "mixed-assignment", "possibly-false-operand", "possibly-invalid-iterator", "possibly-null-array-access", "possibly-null-iterator", "possibly-null-operand", "string-member-selector",
+    # help
+    "redundant-comparison", "redundant-logical-operation"
+]

--- a/.mago/mago.toml
+++ b/.mago/mago.toml
@@ -1,0 +1,37 @@
+# Welcome to Mago!
+# For full documentation, see https://mago.carthage.software/tools/overview
+php-version = "8.1.0"
+
+[source]
+workspace = "."
+paths = ["src/"]
+includes = ["vendor"]
+excludes = []
+
+[formatter]
+print-width = 120
+tab-width = 4
+use-tabs = false
+
+[linter]
+integrations = ["phpunit"]
+
+[linter.rules]
+ambiguous-function-call = { enabled = false }
+literal-named-argument = { enabled = false }
+halstead = { effort-threshold = 7000 }
+
+[analyzer]
+plugins = []
+find-unused-definitions = false
+find-unused-expressions = false
+analyze-dead-code = false
+memoize-properties = true
+allow-possibly-undefined-array-keys = true
+check-throws = false
+check-missing-override = false
+find-unused-parameters = false
+strict-list-index-checks = false
+no-boolean-literal-comparison = false
+check-missing-type-hints = false
+register-super-globals = true


### PR DESCRIPTION
This PR adds mago.toml and mago.yml for GitHub Actions to use Mago as static analysis tools.

Mago is an extremely fast PHP linter, formatter, and static analyzer, written in Rust.
https://github.com/carthage-software/mago