### PR TITLE
Update Composer to 2.10.0-RC2

### DIFF
--- a/.github/actions/setup-php/action.yaml
+++ b/.github/actions/setup-php/action.yaml
@@ -12,7 +12,7 @@ inputs:
   tools:
     description: 'Comma-separated list of tools to install'
     required: false
-    default: composer:2.9.8, phan:6.0.5
+    default: composer:2.10.0-RC2, phan:6.0.5
 
 runs:
   using: "composite"


### PR DESCRIPTION
Updated Composer to 2.10.0-RC2.

ref:
- https://github.com/composer/composer/releases/tag/2.10.0-RC1
- https://github.com/composer/composer/releases/tag/2.10.0-RC2