### PR TITLE
Add persistent session support with automatic token renewal and retry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "phpunit/phpunit": "*",
     "phpstan/phpstan": "^2.0"
   },
+  "suggest": {
+    "ext-apcu": "Optional: required only by the built-in ApcuSessionCache backend."
+  },
   "autoload": {
     "psr-4": {
       "INTERMediator\\FileMakerServer\\RESTAPI\\": "src/"

--- a/src/FMDataAPI.php
+++ b/src/FMDataAPI.php
@@ -2,6 +2,7 @@
 
 namespace INTERMediator\FileMakerServer\RESTAPI;
 
+use INTERMediator\FileMakerServer\RESTAPI\SessionCache\SessionCacheInterface;
 use INTERMediator\FileMakerServer\RESTAPI\Supporting\FileMakerLayout;
 use INTERMediator\FileMakerServer\RESTAPI\Supporting\FileMakerRelation;
 use INTERMediator\FileMakerServer\RESTAPI\Supporting\CommunicationProvider;
@@ -58,23 +59,33 @@ class FMDataAPI
      * Ex.  [{"database"=>"<databaseName>", "username"=>"<username>", "password"=>"<password>"}].
      * If you use OAuth, "oAuthRequestId" and "oAuthIdentifier" keys have to be specified.
      * @param boolean $isUnitTest If it's set to true, the communication provider just works locally.
+     * @param SessionCacheInterface|null $sessionCache Cache backend for persistent sessions.
+     * If omitted, the library logs in and out on every database operation, or once
+     * per communication scope when using startCommunication() / endCommunication().
+     * If specified, session tokens are persisted and reused across requests via
+     * startCommunication() / endCommunication(), avoiding redundant logins against the FileMaker Server.
+     * When a session cache is specified, {@see self::setRetryOnAccessTokenInvalidation()} is
+     * automatically set to true, ensuring the library re-authenticates and retries the request if
+     * the cached token has expired on the FileMaker Server.
      */
-    public function __construct(string      $solution,
-                                string      $user,
-                                string|null $password,
-                                string|null $host = null,
-                                int|null    $port = null,
-                                string|null $protocol = null,
-                                array|null  $fmDataSource = null,
-                                bool        $isUnitTest = false)
+    public function __construct(string                     $solution,
+                                string                     $user,
+                                string|null                $password,
+                                string|null                $host = null,
+                                int|null                   $port = null,
+                                string|null                $protocol = null,
+                                array|null                 $fmDataSource = null,
+                                bool                       $isUnitTest = false,
+                                SessionCacheInterface|null $sessionCache = null)
     {
         if (is_null($password)) {
             $password = "password"; // For testing purpose.
         }
+
         if (!$isUnitTest) {
-            $this->provider = new Supporting\CommunicationProvider($solution, $user, $password, $host, $port, $protocol, $fmDataSource);
+            $this->provider = new Supporting\CommunicationProvider($solution, $user, $password, $host, $port, $protocol, $fmDataSource, $sessionCache);
         } else {
-            $this->provider = new Supporting\TestProvider($solution, $user, $password, $host, $port, $protocol, $fmDataSource);
+            $this->provider = new Supporting\TestProvider($solution, $user, $password, $host, $port, $protocol, $fmDataSource, $sessionCache);
         }
     }
 
@@ -264,33 +275,42 @@ class FMDataAPI
     }
 
     /**
-     * Start a transaction which is a serial calling of multiple database operations before the single authentication.
-     * Usually most methods login and logout before/after the database operation, and so a little bit of time is going to
-     * take.
-     * The startCommunication() login and endCommunication() logout, and methods between them don't log in/out, and
-     * it can expect faster operations.
+     * Start a communication scope with a shared authenticated session.
+     *
+     * Usually most methods login and logout before and after each database operation.
+     * By calling startCommunication() and endCommunication(), methods between them don't
+     * log in and out every time, and it can expect faster operations.
+     *
+     * Without a session cache, one authenticated session is kept for the duration of
+     * the current communication scope and discarded when endCommunication() is called.
+     *
+     * With a session cache, the session token is persisted beyond the current communication
+     * scope and reused across requests. If no cached token is available, a new session is
+     * created and stored for future reuse.
+     *
      * @throws Exception
      */
     public function startCommunication(): void
     {
-        try {
-            if ($this->provider->login()) {
-                $this->provider->keepAuth = true;
-            }
-        } catch (Exception $e) {
-            $this->provider->keepAuth = false;
-            throw $e;
-        }
+        $this->provider->startCommunication();
     }
 
     /**
-     * Finish a transaction which is a serial calling of any database operations, and logout.
+     * Finish a communication scope.
+     *
+     * Without a session cache, the authenticated session for the current communication
+     * scope is ended and the server session is logged out.
+     *
+     * With a session cache, the cached token's TTL is renewed if it still matches the
+     * token held by this instance. If another process has replaced the cached token in
+     * the meantime, only this instance's now-stale token is logged out, leaving the
+     * newer cached token intact.
+     *
      * @throws Exception
      */
     public function endCommunication(): void
     {
-        $this->provider->keepAuth = false;
-        $this->provider->logout();
+        $this->provider->endCommunication();
     }
 
     /**
@@ -424,5 +444,45 @@ class FMDataAPI
     public function setExcludeTimeStampInException(bool $value = true): void
     {
         $this->provider->excludeTimeStampInException = $value;
+    }
+
+    /**
+     * Controls whether failed Data API calls are automatically retried after session invalidation.
+     *
+     * When enabled and a call fails with error 952 (invalid token) or 112 (window missing), the
+     * current session is discarded, a new session is established, and the call is retried once.
+     *
+     * When a session cache is provided to the constructor, retry on token invalidation is always
+     * active regardless of this setting. This flag only has an effect when no session cache is
+     * configured.
+     *
+     * Warning: The retry runs in a fresh session. Any session-scoped state from the original session
+     * is lost — for example, global fields set before the retry will not carry over.
+     * @param bool $value
+     */
+    public function setRetryOnAccessTokenInvalidation(bool $value = true): void
+    {
+        $this->provider->retryOnAccessTokenInvalidation = $value;
+    }
+
+    /**
+     * Overrides the time-to-live (TTL) of the cached FileMaker Data API session token.
+     *
+     * WARNING: Setting a TTL that exceeds the FileMaker Data API session timeout (15 minutes)
+     * will cause the library to use expired tokens, resulting in authentication failures.
+     * Do not use this method unless you fully understand the implications.
+     *
+     * The default TTL is 840 seconds (14 minutes), intentionally set one minute below the
+     * FileMaker Data API session timeout of 15 minutes to ensure the cached token is
+     * invalidated before it expires on the FileMaker Server.
+     * @param int $ttl Time-to-live in seconds. Defaults to 840 seconds (14 minutes).
+     * @throws Exception If a session cache is not set, an exception is thrown.
+     */
+    public function setSessionCacheTtl(int $ttl = 840): void
+    {
+        if ($this->provider->sessionCache === null) {
+            throw new Exception("setSessionCacheTtl() requires a session cache to be configured via the constructor.");
+        }
+        $this->provider->sessionCache->setTtl($ttl);
     }
 }

--- a/src/SessionCache/AbstractSessionCache.php
+++ b/src/SessionCache/AbstractSessionCache.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace INTERMediator\FileMakerServer\RESTAPI\SessionCache;
+
+/**
+ * Base class for session cache implementations.
+ *
+ * Provides the cache key and TTL to concrete implementations, both of which
+ * are managed internally by the library. The cache key and TTL will not change
+ * during a single PHP request.
+ *
+ * As this cache stores FileMaker Data API session tokens, which are sensitive
+ * credentials granting full API access on behalf of the authenticated user,
+ * implementors must ensure that the underlying cache storage is secure and
+ * not accessible to unauthorized parties.
+ *
+ * To provide a custom cache backend, extend this class and implement
+ * {@see SessionCacheInterface::get()}, {@see SessionCacheInterface::set()},
+ * and {@see SessionCacheInterface::delete()}, using {@see self::$key}
+ * and {@see self::$ttl} in your implementations.
+ *
+ * @see ApcuSessionCache for an example implementation using APCu.
+ * @see SessionCacheInterface for an alternative way to implement session caching without
+ * extending this class.
+ */
+abstract class AbstractSessionCache implements SessionCacheInterface
+{
+    /**
+     * The cache key for the current session.
+     *
+     * Always set by the library via {@see SessionCacheInterface::setKey()} before any cache
+     * operation is performed. Will not change during a single PHP request.
+     * Implementing classes should use this property directly in their
+     * {@see SessionCacheInterface::get()}, {@see SessionCacheInterface::set()},
+     * and {@see SessionCacheInterface::delete()} implementations.
+     */
+    protected string $key;
+
+    /**
+     * The time-to-live in seconds for cached session tokens.
+     *
+     * Set by the library via {@see SessionCacheInterface::setTtl()} before any cache operation
+     * is performed, defaulting to the value provided at construction time.
+     * Will not change during a single PHP request. Implementing classes should
+     * use this property directly in their {@see SessionCacheInterface::set()} implementation.
+     *
+     */
+    protected int $ttl;
+
+    /**
+     * @param int $defaultTtl Default time-to-live in seconds for cached session tokens.
+     *                        Defaults to 840 seconds (14 minutes), reflecting the
+     *                        default FileMaker Data API session timeout. Adjust this
+     *                        value if your FileMaker Server is configured with a
+     *                        different session timeout.
+     */
+    public function __construct(int $defaultTtl = 840)
+    {
+        $this->ttl = $defaultTtl;
+    }
+
+    final public function setKey(string $key): void
+    {
+        $this->key = $key;
+    }
+
+    final public function setTtl(int $ttl): void
+    {
+        $this->ttl = $ttl;
+    }
+}

--- a/src/SessionCache/ApcuSessionCache.php
+++ b/src/SessionCache/ApcuSessionCache.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace INTERMediator\FileMakerServer\RESTAPI\SessionCache;
+
+use RuntimeException;
+
+/**
+ * APCu-based session cache implementation.
+ *
+ * Caches FileMaker Data API session tokens using APCu, which stores data in
+ * shared memory on the server. Note that depending on your setup APCu cache
+ * may be shared across PHP processes on the same server, so cache keys must be
+ * sufficiently unique to avoid collisions between different users and applications.
+ *
+ * Requires that the APCu extension is installed and enabled. See the
+ * documentation here for more information: https://www.php.net/apcu
+ *
+ * As this cache stores sensitive FileMaker Data API session tokens, APCu is
+ * only appropriate in environments where server memory access is properly
+ * restricted.
+ *
+ * Note that cache operations in this implementation are not atomic. While care
+ * has been taken to minimize the risk of race conditions, concurrent requests
+ * sharing the same cache key may occasionally result in redundant
+ * re-authentication against the FileMaker Server. This is considered an
+ * acceptable trade-off given the constraints of the current implementation.
+ *
+ * @package INTER-Mediator\FileMakerServer\RESTAPI\SessionCache
+ * @link https://github.com/msyk/FMDataAPI GitHub Repository
+ * @version 36
+ */
+class ApcuSessionCache extends AbstractSessionCache
+{
+    /**
+     * ApcuSessionCache constructor.
+     * @throws RuntimeException If APCu is not available.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        if (!function_exists('apcu_enabled') || !apcu_enabled()) {
+            throw new RuntimeException("APCu is required to use ApcuSessionCache.");
+        }
+    }
+
+    /**
+     * Retrieves the cached FileMaker Data API session token for the current session.
+     *
+     * @return string|null The cached session token, or null if no token exists
+     *                     for the current key.
+     */
+    public function get(): string|null
+    {
+        $value = apcu_fetch($this->key, $success);
+        return $success && is_string($value) ? $value : null;
+    }
+
+    /**
+     * Persists a FileMaker Data API session token in APCu.
+     *
+     * @param string $value The FileMaker Data API session token to store.
+     *                      This is a sensitive credential and must be treated as such.
+     * @return bool True on success, false on failure.
+     */
+    public function set(string $value): bool
+    {
+        return apcu_store($this->key, $value, $this->ttl);
+    }
+
+    /**
+     * Deletes the cached FileMaker Data API session token.
+     *
+     * Returns false both when the key does not exist and when deletion fails.
+     *
+     * @return bool True on success, false if the key did not exist or deletion failed.
+     */
+    public function delete(): bool
+    {
+        return apcu_delete($this->key);
+    }
+}

--- a/src/SessionCache/SessionCacheInterface.php
+++ b/src/SessionCache/SessionCacheInterface.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace INTERMediator\FileMakerServer\RESTAPI\SessionCache;
+
+/**
+ * Interface for session cache implementations.
+ *
+ * Implementations of this interface are used internally by the library to cache
+ * FileMaker Data API session tokens. These tokens are sensitive credentials that
+ * grant access to the FileMaker Data API on behalf of the authenticated user.
+ * Implementors must ensure that cached values are stored securely and are not
+ * accessible to unauthorized parties.
+ *
+ * This interface should not be implemented directly. Instead, extend
+ * {@see AbstractSessionCache}, which provides the cache key and TTL management
+ * required by this interface, and implement the three cache methods.
+ *
+ * @see ApcuSessionCache for an example implementation using APCu.
+ * @see AbstractSessionCache for an easier way to implement session caching, but
+ * this interface is still useful for custom implementations.
+ */
+interface SessionCacheInterface
+{
+    /**
+     * Retrieves the cached FileMaker Data API session token for the current session.
+     *
+     * The cache key is managed internally by the library and set via
+     * {@see setKey()} prior to this method being called.
+     *
+     * @return string|null The cached session token, or null if no token exists
+     *                     for the current key.
+     */
+    public function get(): ?string;
+
+    /**
+     * Persists a FileMaker Data API session token in the cache.
+     *
+     * The value being stored is a sensitive FileMaker Data API session token.
+     * Implementors must ensure this value is stored securely and protected from
+     * unauthorized access, as it grants access to the FileMaker Data API on behalf
+     * of the authenticated user.
+     *
+     * The cache key and TTL are managed internally by the library and set via
+     * {@see setKey()} and {@see setTtl()}
+     * prior to this method being called.
+     *
+     * @param string $value The FileMaker Data API session token to store.
+     *                      This is a sensitive credential and must be treated as such.
+     * @return bool True on success, false on failure.
+     */
+    public function set(string $value): bool;
+
+    /**
+     * Deletes the cached FileMaker Data API session token for the current session.
+     *
+     * The cache key is managed internally by the library and set via
+     * {@see setKey()} prior to this method being called.
+     *
+     * @return bool True on success, false if the key did not exist or deletion failed.
+     */
+    public function delete(): bool;
+
+    /**
+     * Sets the cache key for the current session.
+     *
+     * This method is called internally by the library and should not be called
+     * manually. The key will not change during a single PHP request.
+     *
+     * @param string $key The cache key to use for subsequent cache operations.
+     */
+    public function setKey(string $key): void;
+
+
+    /**
+     * Sets the time-to-live for cached session tokens.
+     *
+     * This method is called internally by the library and should not be called
+     * manually. The TTL will not change during a single PHP request.
+     *
+     * @param int $ttl Time-to-live in seconds for the cached session token.
+     */
+    public function setTtl(int $ttl): void;
+}

--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -5,6 +5,7 @@ namespace INTERMediator\FileMakerServer\RESTAPI\Supporting;
 use DateTime;
 use Exception;
 use CurlHandle;
+use INTERMediator\FileMakerServer\RESTAPI\SessionCache\SessionCacheInterface;
 
 /**
  * Class CommunicationProvider is for internal use to communicate with FileMaker Server.
@@ -148,7 +149,11 @@ class CommunicationProvider
      * @ignore
      */
     public bool $keepAuth = false;
-
+    /**
+     * @var bool
+     * @ignore
+     */
+    public bool $resumeScopeAfterReauth = false;
     /**
      * @var bool
      * @ignore
@@ -222,6 +227,18 @@ class CommunicationProvider
     public bool $excludeTimeStampInException = false;
 
     /**
+     * @var bool
+     * @ignore
+     */
+    public bool $retryOnAccessTokenInvalidation = false;
+
+    /**
+     * @var SessionCacheInterface|null
+     * @ignore
+     */
+    public SessionCacheInterface|null $sessionCache = null;
+
+    /**
      * CommunicationProvider constructor.
      * @param string $solution
      * @param string $user
@@ -230,15 +247,17 @@ class CommunicationProvider
      * @param string|null $port
      * @param string|null $protocol
      * @param array|null $fmDataSource
+     * @param SessionCacheInterface|null $sessionCache
      * @ignore
      */
-    public function __construct(string      $solution,
-                                string      $user,
-                                string      $password,
-                                string|null $host = null,
-                                string|null $port = null,
-                                string|null $protocol = null,
-                                array|null  $fmDataSource = null)
+    public function __construct(string                     $solution,
+                                string                     $user,
+                                string                     $password,
+                                string|null                $host = null,
+                                string|null                $port = null,
+                                string|null                $protocol = null,
+                                array|null                 $fmDataSource = null,
+                                SessionCacheInterface|null $sessionCache = null)
     {
         $this->solution = rawurlencode($solution);
         $this->user = $user;
@@ -260,7 +279,68 @@ class CommunicationProvider
             }
         }
         $this->fmDataSource = $fmDataSource;
+        $this->sessionCache = $sessionCache;
         $this->errorCode = -1;
+        if ($this->sessionCache !== null) {
+            $this->sessionCache->setKey($this->cacheKey());
+        }
+    }
+
+    /**
+     * Start a communication scope with a shared authenticated session.
+     *
+     * Without a session cache, a new authenticated session is created and kept
+     * for the duration of the current communication scope.
+     *
+     * With a session cache, the cached session token is reused if available,
+     * avoiding a new login against the FileMaker Server. If no cached token is
+     * found, a new session is created and stored in the cache for future reuse.
+     *
+     * @throws Exception In case of any error, an exception arises.
+     */
+    public function startCommunication(): void
+    {
+        try {
+            $this->keepAuth = $this->login();
+        } catch (Exception $e) {
+            $this->keepAuth = false;
+            throw $e;
+        }
+    }
+
+    /**
+     * Finish a communication scope.
+     *
+     * Without a session cache, the authenticated session is ended and the server
+     * session is logged out.
+     *
+     * With a session cache, if the token currently held by this instance matches
+     * the one in the cache, its TTL is renewed and the session is left alive.
+     * If another process has replaced the cached token in the meantime, this
+     * instance's now-stale token is considered orphaned and logged out at the
+     * server, leaving the newer cached token intact.
+     *
+     * @throws Exception In case of any error, an exception arises.
+     */
+    public function endCommunication(): void
+    {
+        $this->keepAuth = false;
+        $this->resumeScopeAfterReauth = false;
+
+        if ($this->sessionCache !== null && $this->accessToken !== null) {
+            if ($this->sessionCache->get() === $this->accessToken) {
+                // if the cache write fails, the token will expire naturally within 15 minutes.
+                // under sustained cache failures with high concurrency, orphaned tokens could
+                // approach FileMaker's session cap (error 953).
+                $this->sessionCache->set($this->accessToken); // renew TTL
+                $this->accessToken = null;
+                return;
+            }
+            // Mismatch: another worker replaced the cached token while we were active.
+            // Our token is an orphan — fall through and DELETE it, but don't touch the cache.
+        }
+
+        $this->logout();
     }
 
     /**
@@ -490,6 +570,18 @@ class CommunicationProvider
             return true;
         }
 
+        if ($this->sessionCache !== null) {
+            $cached = $this->sessionCache->get();
+            if ($cached !== null) {
+                $this->accessToken = $cached;
+                if ($this->resumeScopeAfterReauth) {
+                    $this->keepAuth = true;
+                    $this->resumeScopeAfterReauth = false;
+                }
+                return true;
+            }
+        }
+
         if ($this->useOAuth) {
             $headers = [
                 "Content-Type" => "application/json",
@@ -507,10 +599,17 @@ class CommunicationProvider
         $request = [];
         $request["fmDataSource"] = (!is_null($this->fmDataSource)) ? $this->fmDataSource : [];
         try {
-            $this->callRestAPI($params, false, "POST", $request, $headers); // Throw Exception
+            $this->callRestAPIWithoutRetry($params, false, "POST", $request, $headers); // Throw Exception
             $this->storeToProperties();
             if ($this->httpStatus == 200 && $this->errorCode == 0) {
                 $this->accessToken = $this->responseBody->response->token;
+                if ($this->sessionCache !== null) {
+                    $this->sessionCache->set($this->accessToken);
+                }
+                if ($this->resumeScopeAfterReauth) {
+                    $this->keepAuth = true;
+                    $this->resumeScopeAfterReauth = false;
+                }
                 return true;
             }
         } catch (Exception $e) {
@@ -521,7 +620,10 @@ class CommunicationProvider
     }
 
     /**
-     *
+     * Tear down the current server-side session, unless either:
+     *   - we're inside a multi-call scope (keepAuth), or
+     *   - this token is the one currently shared via the persistent cache
+     *     (in which case the cache owns its lifecycle).
      * @return void
      * @throws Exception In case of any error, an exception arises.
      * @ignore
@@ -531,9 +633,20 @@ class CommunicationProvider
         if ($this->keepAuth) {
             return;
         }
-        $params = ["sessions" => $this->accessToken];
-        $this->callRestAPI($params, true, "DELETE"); // Throw Exception
-        $this->accessToken = null;
+        if ($this->accessToken === null) {
+            return;
+        }
+        if ($this->sessionCache !== null && $this->sessionCache->get() === $this->accessToken) {
+            $this->accessToken = null;
+            return;
+        }
+
+        try {
+            $params = ["sessions" => $this->accessToken];
+            $this->callRestAPIWithoutRetry($params, true, "DELETE"); // Throw Exception
+        } finally {
+            $this->accessToken = null;
+        }
     }
 
     /**
@@ -591,6 +704,8 @@ class CommunicationProvider
     }
 
     /**
+     * Sends a REST API request to the FileMaker Data API, retrying once on session invalidation if
+     * the retryOnAccessTokenInvalidation property is enabled.
      * @param array $params
      * @param bool $isAddToken
      * @param string $method
@@ -599,7 +714,9 @@ class CommunicationProvider
      * @param bool $isSystem for Metadata
      * @param string|null|false $directPath
      * @return void
-     * @throws Exception In case of any error, an exception arises.
+     * @throws Exception In case of any error, an exception arises. If a retry was attempted,
+     *                   the original exception is available via getPrevious().
+     * @see callRestAPIWithoutRetry() To bypass retry logic entirely.
      * @ignore
      */
     public function callRestAPI(array             $params,
@@ -609,6 +726,69 @@ class CommunicationProvider
                                 array|null        $addHeader = null,
                                 bool              $isSystem = false,
                                 string|null|false $directPath = null): void
+    {
+        $firstAttempt = null;
+        try {
+            $this->callRestAPIWithoutRetry($params, $isAddToken, $method, $request, $addHeader, $isSystem, $directPath);
+        } catch (Exception $e) {
+            $firstAttempt = $e;
+        }
+
+        if (!$this->shouldRetryOnTokenError()) {
+            if ($firstAttempt !== null) {
+                throw $firstAttempt;
+            }
+            return;
+        }
+
+        // Token rejected by the server. Clear the cache before re-login so racing workers
+        // don't re-adopt the dead token; preserve the in-process scope across the re-login.
+        if ($this->sessionCache !== null) {
+            $this->sessionCache->delete();
+        }
+        $resumeScope = $this->keepAuth;
+        $this->accessToken = null;
+        $this->keepAuth = false;
+        try {
+            if (!$this->login()) {
+                $this->resumeScopeAfterReauth = $resumeScope;
+                return;
+            }
+        } catch (Exception $e) {
+            $this->resumeScopeAfterReauth = $resumeScope;
+            throw new Exception($e->getMessage(), $e->getCode(), $firstAttempt);
+        }
+
+        // The login was successful here — retry the original call
+        $this->keepAuth = $resumeScope;
+        try {
+            $this->callRestAPIWithoutRetry($params, $isAddToken, $method, $request, $addHeader, $isSystem, $directPath);
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage(), $e->getCode(), $firstAttempt);
+        }
+    }
+
+    /**
+     * Sends a REST API request to the FileMaker Data API without any retry logic.
+     * @param array $params
+     * @param bool $isAddToken
+     * @param string $method
+     * @param string|array|null $request
+     * @param array|null $addHeader
+     * @param bool $isSystem for Metadata
+     * @param string|null|false $directPath
+     * @return void
+     * @throws Exception In case of any error, an exception arises.
+     * @see callRestAPI() For the recommended entry point with automatic retry on session invalidation.
+     * @ignore
+     */
+    protected function callRestAPIWithoutRetry(array             $params,
+                                               bool              $isAddToken,
+                                               string            $method = 'GET',
+                                               string|array|null $request = null,
+                                               array|null        $addHeader = null,
+                                               bool              $isSystem = false,
+                                               string|null|false $directPath = null): void
     {
         $methodLower = strtolower($method);
         $url = $this->getURL($params, $request, $methodLower, $isSystem, $directPath);
@@ -835,6 +1015,39 @@ class CommunicationProvider
     }
 
     /**
+     * @return bool
+     * @ignore
+     */
+    private function shouldRetryOnTokenError(): bool
+    {
+        if ($this->sessionCache === null && !$this->retryOnAccessTokenInvalidation) {
+            return false;
+        }
+
+        $errorCode = $this->extractErrorCode();
+        // Error code 952 - Invalid FileMaker Data API token
+        //                  Occurs when the access token has expired or been invalidated.
+        // Error code 112 - "Window is missing" (likely unintentional by the FileMaker Data API)
+        //                  Reproducible when a Data API session is closed externally mid-request,
+        //                  producing a spurious "window missing" error rather than a proper auth failure.
+        return $errorCode === 952 || $errorCode === 112;
+    }
+
+    /**
+     * @return int
+     * @ignore
+     */
+    private function extractErrorCode(): int
+    {
+        $errorCode = -1;
+        if (is_object($this->responseBody) && property_exists($this->responseBody, 'messages')) {
+            $result = $this->responseBody->messages[0];
+            $errorCode = property_exists($result, 'code') ? intval($result->code) : -1;
+        }
+        return $errorCode;
+    }
+
+    /**
      * @param array $value
      * @return string
      * @ignore
@@ -913,5 +1126,20 @@ class CommunicationProvider
             curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         }
         return $ch;
+    }
+
+    private function cacheKey(): string
+    {
+        $data = [
+            $this->user,
+            $this->solution,
+            (string)$this->port,
+            $this->host,
+            $this->protocol,
+        ];
+
+        $hash = hash('sha256', implode("\0", $data));
+
+        return "fm_token_$hash";
     }
 }

--- a/src/Supporting/FileMakerLayout.php
+++ b/src/Supporting/FileMakerLayout.php
@@ -42,25 +42,42 @@ class FileMakerLayout
     }
 
     /**
-     * Start a transaction which is a serial calling of any database operations
-     * and log in with the target layout.
+     * Start a communication scope with a shared authenticated session.
+     *
+     * Usually most methods login and logout before and after each database operation.
+     * By calling startCommunication() and endCommunication(), methods between them don't
+     * log in and out every time, and it can expect faster operations.
+     *
+     * Without a session cache, one authenticated session is kept for the duration of
+     * the current communication scope and discarded when endCommunication() is called.
+     *
+     * With a session cache, the session token is persisted beyond the current communication
+     * scope and reused across requests. If no cached token is available, a new session is
+     * created and stored for future reuse.
+     *
      * @throws Exception
      */
     public function startCommunication(): void
     {
-        if ($this->restAPI->login()) {
-            $this->restAPI->keepAuth = true;
-        }
+        $this->restAPI->startCommunication();
     }
 
     /**
-     * Finish a transaction which is a serial calling of any database operations, and logout.
+     * Finish a communication scope.
+     *
+     * Without a session cache, the authenticated session for the current communication
+     * scope is ended and the server session is logged out.
+     *
+     * With a session cache, the cached token's TTL is renewed if it still matches the
+     * token held by this instance. If another process has replaced the cached token in
+     * the meantime, only this instance's now-stale token is logged out, leaving the
+     * newer cached token intact.
+     *
      * @throws Exception
      */
     public function endCommunication(): void
     {
-        $this->restAPI->keepAuth = false;
-        $this->restAPI->logout();
+        $this->restAPI->endCommunication();
     }
 
     /**

--- a/test/TestProvider.php
+++ b/test/TestProvider.php
@@ -9,6 +9,7 @@
 namespace INTERMediator\FileMakerServer\RESTAPI\Supporting;
 
 use Exception;
+use INTERMediator\FileMakerServer\RESTAPI\SessionCache\SessionCacheInterface;
 
 class TestProvider extends CommunicationProvider
 {
@@ -22,17 +23,19 @@ class TestProvider extends CommunicationProvider
      * @param string|null $port
      * @param string|null $protocol
      * @param array|null $fmDataSource
+     * @param SessionCacheInterface|null $sessionCache
      * @ignore
      */
-    public function __construct(string      $solution,
-                                string      $user,
-                                string|null $password,
-                                string|null $host = null,
-                                string|null $port = null,
-                                string|null $protocol = null,
-                                array|null  $fmDataSource = null)
+    public function __construct(string                     $solution,
+                                string                     $user,
+                                string|null                $password,
+                                string|null                $host = null,
+                                string|null                $port = null,
+                                string|null                $protocol = null,
+                                array|null                 $fmDataSource = null,
+                                SessionCacheInterface|null $sessionCache = null)
     {
-        parent::__construct($solution, $user, $password, $host, $port, $protocol, $fmDataSource);
+        parent::__construct($solution, $user, $password, $host, $port, $protocol, $fmDataSource, $sessionCache);
         $this->buildResponses();
     }
 
@@ -49,13 +52,13 @@ class TestProvider extends CommunicationProvider
      * @throws Exception In case of any error, an exception arises.
      * @ignore
      */
-    public function callRestAPI(array             $params,
-                                bool              $isAddToken,
-                                string            $method = 'GET',
-                                array|null|string $request = null,
-                                array|null        $addHeader = null,
-                                bool              $isSystem = false,
-                                string|null|false $directPath = null): void
+    protected function callRestAPIWithoutRetry(array             $params,
+                                               bool              $isAddToken,
+                                               string            $method = 'GET',
+                                               array|null|string $request = null,
+                                               array|null        $addHeader = null,
+                                               bool              $isSystem = false,
+                                               string|null|false $directPath = null): void
     {
         $methodLower = strtolower($method);
         $url = $this->getURL($params, $request, $methodLower);


### PR DESCRIPTION
## Overview

By default the library logs in and out on every single database operation, which means a full authentication round-trip each time. The library already supports performing several Data API calls under one PHP request, but this still means a full authentication round-trip each PHP request. This PR adds opt-in support for sharing a session token across PHP requests, so only the first request pays the cost of logging in — every subsequent request on the same server reuses the cached token instead.

This PR adds two features:
1. **Persistent sessions** — This is what allows several PHP requests to share a single Data API session token. This is entirely opt-in, and is done by specifying the new `sessionCache` constructor parameter on `FMDataAPI`. 
2. **Retry mechanism** — Another opt-in feature, which allow a request to retry once more with a new Data API session, if the current session were invalidated in the middle of a PHP request. This is useful when using `startCommunication()`. Without a session cache specified in the `FMDataAPI` contructor, it requres explicitely calling `setRetryOnAccessTokenInvalidation(true)`.

The persistent sessions have the retry mechanism enabled by design, as it would not make sense to use persistent sessions without any way of renewing an expired session.

Omitting both the `sessionCache` constructor parameter and `setRetryOnAccessTokenInvalidation(true)` method keeps all existing behavior intact.

This PR provides a default cache backend, APCu, for those that have it enabled. It is deliberately not a requirement of the package, and will only work for those that have APCu enabled.

---

## How to use it

Pass a cache backend to the constructor and the library handles the rest — storing the token after login, reusing it on subsequent requests, and automatically recovering if the token goes stale.

```php
$fm = new FMDataAPI(
    solution: 'MyDatabase',
    user: 'admin',
    password: 'secret',
    host: 'filemaker.example.com',
    sessionCache: new ApcuSessionCache(),
);

// The first request logs in and caches the token.
// Subsequent requests from any PHP worker on this server reuse it.
$fm->startCommunication();
$records = $fm->layout('Contacts')->query();
$fm->endCommunication();
// endCommunication() renews the cache TTL instead of logging out.
```

New behavior of `startCommunication()` and `endCommunication()` whenever a session cache is specified:
- `startCommunication()` — This stored the access token locally as normal. Without this, the request token would be read from the cache on each request, which is still fast.
- `endCommunication()` — Same as before, with the addition of being the only location where the cached item's TTL being updated. The details of this choice will be elaborated on further down.

The default cache TTL is set to 840 seconds, which leaves a 60 seconds buffer before Data API access token would expire on the FileMaker Server-side.

This PR supports custom cache backends through two different approaches:
1. Extend `AbstractSessionCache` (this already implements `SessionCacheInterface`, used to reduce boilerplate)
2. Implement `SessionCacheInterface`.

See `ApcuSessionCache` on how to extend `AbstractSessionCache`. If you want to implement `SessionCacheInterface` directly, see both `ApcuSessionCache` and `AbstractSessionCache`.

---

## New files

- **`AbstractSessionCache.php`** — public API. Includes properties and setter functions, which reduces boilerplate for custom cache implemetations.
- **`ApcuSessionCache.php`** — public API. Ready-made APCu implementation. Throws if APCu isn't available.
- **`SessionCacheInterface.php`** — public API. Five methods: `get`, `set` (with TTL), `delete`, `setTtl`, `setKey`. These will need to be implemented if you want to extend `AbstractSessionCache`.

---

## Changes to existing files

### Review carefully

**`src/Supporting/CommunicationProvider.php`** — the core of this PR. Most of the new logic lives here.

- New `$resumeScopeAfterReauth` property. This only serves as a way to remember if `keepAuth` were set before renewing the session through the new retry-mechanism.
- New `$retryOnAccessTokenInvalidation` property. This tells the application if it should retry a failed call if an Data API session token invalidation error occured. 
- New `$sessionStore` property. The instance of the session cache that is used for persistent sessions.
- **`startCommunication()` (moved)** — sets `keepAuth` to the return value of `login()`, so it's only ever true when login actually succeeded.
- **`endCommunication()` (moved)** — same as the old `endCommunication()`, but if persistent session are used: If the cached token matches ours, renews the TTL and skips the server logout. If tokens differ, another worker has replaced the cached token; ours is an orphan and gets `DELETE`d. Falls through to `logout()` when no cache is configured. Reasoning further down.
- **`login()`** — checks the cache before attempting an HTTP login. After a fresh login, stores the token in the cache. Changed to call `callRestAPIWithoutRetry` internally.
- **`logout()`** — three new guards: returns early if `accessToken` is null; returns early if the token matches the cache; wraps the `DELETE` in `try/finally`.
- **`callRestAPI()` / `callRestAPIWithoutRetry()`** — the original `callRestAPI` is renamed to `callRestAPIWithoutRetry` and made protected. The new `callRestAPI` wraps it with retry logic on 952/112, clearing the cache, re-logging in, and retrying once. The original exception is available via `getPrevious()`.

### Mechanical changes — safe to skim

- **`FMDataAPI.php`** — new `$sessionCache` constructor parameter; `startCommunication()` and `endCommunication()` delegate to the provider; new `setRetryOnAccessTokenInvalidation()` method.
- **`FileMakerLayout.php`** — `startCommunication()` and `endCommunication()` delegate to the provider.
- **`TestProvider.php`** — constructor updated to accept and forward `SessionCacheInterface|null` to the parent.

---

## Behavioural changes for existing users

These apply regardless of whether a session cache is configured.

Please verify all of these.

- **`logout()` null guard** — previously, calling `logout()` with no active session would fire a `DELETE /sessions/` request with a null token in the URL. Before in the case when `throwExceptionInError` was set, this would always throw an exception since this is an invalid operation (it creates a malformed header). Now it immediately returns. This should never occur in the first place, and if `accessToken` is already null, then we should already be logged out.
- **`logout()` try/finally** — `accessToken` is now always nulled after a `DELETE` attempt, even if the request throws. Previously a thrown exception left it set.
- **`startCommunication()` login-failure fix** — This one were divided into two files. In `FMDataAPI.php`, then `keepAuth` were never set to `false` in non-throwing mode. In `FileMakerLayout.php` then `keepAuth` were never set to false in case of a failed login at all. Now, in case of any error, then `keepAuth` is set to false and `keepAuth` is only set to true on a successful login.
- **`endCommunication()`** — When a session cache is enabled, this method now only logs out sessions where the local `accessToken` does not match the cached session token. This is to ensure that one, and only one, session token is stored in the cache. This is also the only place where the TTL of the cached token is renewed.
- **Retry on 952/112** — opt-in. Without a session cache, call `setRetryOnAccessTokenInvalidation(true)` to enable it. With a session cache it activates automatically, since a persistent session that can't recover from an expired token is effectively broken. The retry runs in a fresh session — session-scoped state like global fields set before the failure won't carry over.

---

## Known limitations

Currently, when a session cache is used, the value stored in the key-value pair only has its TTL renewed upon calling `endCommunication()`. This is a deliberate choice as APCu is not atomic and this minimizes the risk of race conditions (rather than setting it after each `callRestAPI` (which increases the surface for race conditions). This means that if an application does not call `endCommunication()` within 14 minutes from opening the session, then the session will be invalidated in the cache and a new session will be started on the next FileMaker Data API request. This is not an issue, since after 14 minutes, the retry-mechanism catches the invalidated token and retries with a new session.

---

## Race conditions and stale tokens

If multiple workers miss the cache simultaneously (on cold start or after a 952 clears it), each logs in independently and gets its own token. Last writer wins the cache; the rest become orphans and idle out within FM Server's 15-minute timeout. `endCommunication()` mitigates this by explicitly `DELETE`ing a token when it finds the cache has already moved on, but workers that crash mid-scope won't get that cleanup. If your FM Server has a low per-user session limit and you anticipate frequent simultaneous cold starts, consider warming the cache from a single entry point before traffic arrives.

Under sustained cache failure in `endCommunication()` with high concurrency, orphaned tokens could approach FileMaker's session cap (error 953).

## Regarding tests

I have modified `TestProvider` to take in `$sessionCache` and replaced the `callRestAPI()` override to now override `callRestAPIWithoutRetry()` (as I renamed that function). However, I'm not sure how the tests in this repositories are used, and I'm not sure how to even run them, so I'll leave the testing to you (msyk). If you feel the need to add any tests to this, feel free to do so.

## Other

As we have already discussed, this PR treats both FileMaker error codes 952 and 112 as a Data API session token invalidation. This was because I could consistently replicate the FileMaker Server returning error code 112 when a Data API session token were invalidated during FileMaker Server Data API request.