### PR TITLE
Integrate Takumi Guard into the CI workflows

### DIFF
--- a/.github/actions/setup-php/action.yaml
+++ b/.github/actions/setup-php/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup PHP
-      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
       with:
         php-version: ${{ inputs.php-version }}
         coverage: none

--- a/.github/actions/setup-php/action.yaml
+++ b/.github/actions/setup-php/action.yaml
@@ -24,3 +24,6 @@ runs:
         coverage: none
         extensions: ${{ inputs.extensions }}
         tools: ${{ inputs.tools }}
+
+    - name: Setup Takumi Guard
+      uses: flatt-security/setup-takumi-guard-packagist@bed25614416656a553e0a5d2bd379be72adcfd4f # v1.1.0

--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
         uses: ./.github/actions/setup-php

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,7 @@ jobs:
         php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
         uses: ./.github/actions/setup-php

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           - current-level: 4
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
         uses: ./.github/actions/setup-php

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
         uses: ./.github/actions/setup-php

--- a/.github/workflows/save-baseline.yml
+++ b/.github/workflows/save-baseline.yml
@@ -13,7 +13,7 @@ jobs:
     name: Save Baseline
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup PHP
         uses: ./.github/actions/setup-php


### PR DESCRIPTION
Added flatt-security/setup-takumi-guard-packagist action to the setup-php composite action.

ref:
- https://shisho.dev/docs/ja/r/202606-takumi-guard-admin-deployment-packagist/
- https://shisho.dev/docs/ja/t/guard/quickstart/packagist/