### PR TITLE
Fix type safety issues reported by Mago static analyzer

### DIFF
--- a/.github/workflows/mago.yml
+++ b/.github/workflows/mago.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/setup-php
 
       - name: Install Mago
-        run: composer config --no-plugins allow-plugins.carthage-software/mago true; composer require --dev carthage-software/mago:1.9.1
+        run: composer config --no-plugins allow-plugins.carthage-software/mago true; composer require --dev carthage-software/mago:1.42.0
 
       - name: Run Mago
         run: ./vendor/bin/mago --config .mago/mago.toml analyze

--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -1114,8 +1114,9 @@ class CommunicationProvider
             This fixes SSL validation errors if `php.ini` doesn't have [curl] `curl.cainfo`,
             set properly of if this PEM file isn't up to date.
             Better rely on the OS certificate authorities, which is maintained automatically. */
+            $curlVersion = curl_version();
             if (defined('CURLSSLOPT_NATIVE_CA')
-                && version_compare(curl_version()['version'], '7.71', '>=')) {
+                && is_array($curlVersion) && version_compare($curlVersion['version'], '7.71', '>=')) {
                 curl_setopt($ch, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
             }
         } else {

--- a/src/Supporting/FileMakerRelation.php
+++ b/src/Supporting/FileMakerRelation.php
@@ -61,7 +61,7 @@ class FileMakerRelation implements Iterator
     /**
      * FileMakerRelation constructor.
      *
-     * @param array<object> $responseData
+     * @param array|object $responseData
      * @param object|array|null $infoData
      * @param string $result
      * @param int $errorCode
@@ -263,7 +263,8 @@ class FileMakerRelation implements Iterator
     private function getNumberedRecord(int $num): ?FileMakerRelation
     {
         $value = null;
-        if (isset($this->data[$num])) {
+        $data = $this->data;
+        if (is_array($data) && isset($data[$num])) {
             $tmpInfo = $this->getDataInfo();
             $dataInfo = null;
             if (is_object($tmpInfo)) {
@@ -271,7 +272,7 @@ class FileMakerRelation implements Iterator
                 $dataInfo->returnedCount = 1;
             }
             $value = new FileMakerRelation(
-                $this->data[$num], $dataInfo, ($this->result == "PORTAL") ? "PORTALRECORD" : "RECORD",
+                $data[$num], $dataInfo, ($this->result == "PORTAL") ? "PORTALRECORD" : "RECORD",
                 $this->errorCode, $this->portalName, $this->restAPI);
         }
         return $value;
@@ -542,7 +543,8 @@ class FileMakerRelation implements Iterator
         switch ($this->result) {
             case "OK":
             case "PORTAL":
-                if (isset($this->data[$this->pointer])) {
+                $data = $this->data;
+                if (is_array($data) && isset($data[$this->pointer])) {
                     $tmpInfo = $this->getDataInfo();
                     $dataInfo = null;
                     if (is_object($tmpInfo)) {
@@ -551,7 +553,7 @@ class FileMakerRelation implements Iterator
                     }
                     $result = ($this->result == "PORTAL") ? "PORTALRECORD" : "RECORD";
                     $portalName = $this->portalName;
-                    $value = new FileMakerRelation($this->data[$this->pointer], $dataInfo, $result,
+                    $value = new FileMakerRelation($data[$this->pointer], $dataInfo, $result,
                         $this->errorCode, $portalName, $this->restAPI);
                 }
                 break;


### PR DESCRIPTION
This PR fixes the following issues reported by the latest Mago.
```
% mago --version
mago 1.42.0
% git log -1 | head -n 1
commit 8aec368db84e19eb8a3701f2c6798fdeb209be3b
% mago --config .mago/mago.toml analyze                    
warning[possibly-false-array-access]: Cannot perform array access on possibly `false` value.
     ┌─ src/Supporting/CommunicationProvider.php:1118:36
     │
1118 │                 && version_compare(curl_version()['version'], '7.71', '>=')) {
     │                                    ^^^^^^^^^^^^^^ The expression might be `false` here.
     │
     = Attempting to read an array index on `false` will result in a runtime error.
     = Help: Ensure the variable holds an array before accessing it, possibly by checking with `is_array()` or `!== false`.

error[docblock-parameter-narrowing]: Docblock type `array<array-key, object>` for parameter `$responseData` drops part of native type `array<array-key, mixed>|object`.
   ┌─ src/Supporting/FileMakerRelation.php:73:33
   │
64 │      * @param array<object> $responseData
   │               ------------- ...but docblock only covers `array<array-key, object>`
   ·
73 │     public function __construct(array|object           $responseData,
   │                                 ^^^^^^^^^^^^ Native type accepts `array<array-key, mixed>|object`, including `object`...
   │
   = Callers can still pass values of the excluded branches.
   = The docblock tells the analyzer those branches are impossible.
   = Narrowing checks can then collapse to `never` in the body.
   = Help: Widen the docblock to `array<array-key, mixed>|object`, or tighten the native type.

warning[possibly-invalid-array-access]: Cannot perform array access on value of type `object`.
    ┌─ src/Supporting/FileMakerRelation.php:274:17
    │
274 │                 $this->data[$num], $dataInfo, ($this->result == "PORTAL") ? "PORTALRECORD" : "RECORD",
    │                 ^^^^^^^^^^^ The expression might be `object` here.
    │
    = Attempting to use a scalar value as an array will result in a runtime error.
    = Help: Ensure the variable holds an array before accessing it.

warning[possibly-invalid-array-access]: Cannot perform array access on value of type `object`.
    ┌─ src/Supporting/FileMakerRelation.php:554:52
    │
554 │                     $value = new FileMakerRelation($this->data[$this->pointer], $dataInfo, $result,
    │                                                    ^^^^^^^^^^^ The expression might be `object` here.
    │
    = Attempting to use a scalar value as an array will result in a runtime error.
    = Help: Ensure the variable holds an array before accessing it.

error: found 4 issues: 1 error(s), 3 warning(s)
```