### PR TITLE
Add __isset magic method to FileMakerRelation for field existence checks

### DIFF
--- a/src/Supporting/FileMakerRelation.php
+++ b/src/Supporting/FileMakerRelation.php
@@ -218,6 +218,22 @@ class FileMakerRelation implements Iterator
     }
 
     /**
+     * Handle the isset() function for the field or portal name.
+     * @param string $key The field or portal name.
+     * @return bool True if the field or portal exists.
+     * @ignore
+     */
+    public function __isset(string $key): bool
+    {
+        try {
+            $this->field($key);
+            return true;
+        } catch (Exception $e) {
+            return false;
+        }
+    }
+
+    /**
      * Return the array of field names.
      *
      * @return array List of field names


### PR DESCRIPTION
Summary: This pull request adds support for the PHP `isset()` function when checking for fields or portals on a record object (`FileMakerRelation`).

Changes:
- Implemented the` __isset` magic method in `src/Supporting/FileMakerRelation.php`.
- The implementation uses the existing `field()` method to verify if a field or portal exists.
- Returns `true` if the field exists and false if it does not (handling the `Exception` thrown by `field()`).

Reasoning: Currently, the library supports magic property access via `__get`, but calling `isset($record->field_name)` always returns false because `__isset` was not implemented. This change makes the API more intuitive and consistent with standard PHP object behavior, allowing developers to safely check for field existence before access.