### PR TITLE
Use boolean values for curl_setopt options that expect bool type

### DIFF
--- a/src/Supporting/CommunicationProvider.php
+++ b/src/Supporting/CommunicationProvider.php
@@ -800,11 +800,11 @@ class CommunicationProvider
             $request = $this->justifyRequest($request);
         }
         $ch = $this->_createCurlHandle($url);
-        curl_setopt($ch, CURLOPT_VERBOSE, 0);
-        curl_setopt($ch, CURLOPT_HEADER, 1);
+        curl_setopt($ch, CURLOPT_VERBOSE, false);
+        curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         if ($methodLower == 'post') {
-            curl_setopt($ch, CURLOPT_POST, 1);
+            curl_setopt($ch, CURLOPT_POST, true);
         } elseif (in_array($methodLower, ['put', 'patch', 'delete', 'get'], true)) {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, strtoupper($methodLower));
         }
@@ -1109,7 +1109,7 @@ class CommunicationProvider
         curl_setopt($ch, CURLOPT_SSLVERSION, CURL_SSLVERSION_DEFAULT);
         if ($this->isCertValidating) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
             /* Use the OS native certificate authorities, if possible.
             This fixes SSL validation errors if `php.ini` doesn't have [curl] `curl.cainfo`,
             set properly of if this PEM file isn't up to date.
@@ -1121,7 +1121,7 @@ class CommunicationProvider
             }
         } else {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         }
         if (!is_null($this->timeout)) {
             curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);


### PR DESCRIPTION
Replace integer 0/1 with false/true for CURLOPT_VERBOSE, CURLOPT_HEADER, CURLOPT_POST, and CURLOPT_SSL_VERIFYPEER to satisfy PHPStan level 5 strict type checking.